### PR TITLE
Switch from `EMSCRIPTEN` to `__EMSCRIPTEN__`

### DIFF
--- a/cocos2dx/CCDirector.cpp
+++ b/cocos2dx/CCDirector.cpp
@@ -1052,9 +1052,9 @@ void DisplayLinkDirector::startAnimation(void)
     }
 
     _invalid = false;
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
     Application::getInstance()->setAnimationInterval(_animationInterval);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 }
 
 void DisplayLinkDirector::mainLoop(void)

--- a/cocos2dx/cocoa/CCObject.h
+++ b/cocos2dx/cocoa/CCObject.h
@@ -27,9 +27,9 @@ THE SOFTWARE.
 
 #include "cocoa/CCDataVisitor.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <GLES2/gl2.h>
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 

--- a/cocos2dx/draw_nodes/CCDrawingPrimitives.cpp
+++ b/cocos2dx/draw_nodes/CCDrawingPrimitives.cpp
@@ -61,7 +61,7 @@ static Color4F s_color(1.0f,1.0f,1.0f,1.0f);
 static int s_pointSizeLocation = -1;
 static GLfloat s_pointSize = 1.0f;
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 static GLuint s_bufferObject = 0;
 static GLuint s_bufferSize = 0;
 
@@ -86,7 +86,7 @@ static void setGLBufferData(void *buf, GLuint bufSize)
     }
 }
 
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 static void lazy_init( void )
 {
@@ -134,12 +134,12 @@ void drawPoint( const Point& point )
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
     s_shader->setUniformLocationWith1f(s_pointSizeLocation, s_pointSize);
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(&p, 8);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, &p);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     glDrawArrays(GL_POINTS, 0, 1);
 
@@ -162,12 +162,12 @@ void drawPoints( const Point *points, unsigned int numberOfPoints )
     // iPhone and 32-bit machines optimization
     if( sizeof(Point) == sizeof(Vertex2F) )
     {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         setGLBufferData((void*) points, numberOfPoints * sizeof(Point));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, points);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     }
     else
     {
@@ -176,14 +176,14 @@ void drawPoints( const Point *points, unsigned int numberOfPoints )
             newPoints[i].x = points[i].x;
             newPoints[i].y = points[i].y;
         }
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         // Suspect Emscripten won't be emitting 64-bit code for a while yet,
         // but want to make sure this continues to work even if they do.
         setGLBufferData(newPoints, numberOfPoints * sizeof(Vertex2F));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, newPoints);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     }
 
     glDrawArrays(GL_POINTS, 0, (GLsizei) numberOfPoints);
@@ -208,12 +208,12 @@ void drawLine( const Point& origin, const Point& destination )
     s_shader->setUniformLocationWith4fv(s_colorLocation, (GLfloat*) &s_color.r, 1);
 
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, 16);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_LINES, 0, 2);
 
     CC_INCREMENT_GL_DRAWS(1);
@@ -252,12 +252,12 @@ void drawPoly( const Point *poli, unsigned int numberOfPoints, bool closePolygon
     // iPhone and 32-bit machines optimization
     if( sizeof(Point) == sizeof(Vertex2F) )
     {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         setGLBufferData((void*) poli, numberOfPoints * sizeof(Point));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, poli);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
         if( closePolygon )
             glDrawArrays(GL_LINE_LOOP, 0, (GLsizei) numberOfPoints);
@@ -273,12 +273,12 @@ void drawPoly( const Point *poli, unsigned int numberOfPoints, bool closePolygon
             newPoli[i].x = poli[i].x;
             newPoli[i].y = poli[i].y;
         }
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         setGLBufferData(newPoli, numberOfPoints * sizeof(Vertex2F));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, newPoli);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
         if( closePolygon )
             glDrawArrays(GL_LINE_LOOP, 0, (GLsizei) numberOfPoints);
@@ -307,12 +307,12 @@ void drawSolidPoly( const Point *poli, unsigned int numberOfPoints, Color4F colo
     // iPhone and 32-bit machines optimization
     if( sizeof(Point) == sizeof(Vertex2F) )
     {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         setGLBufferData((void*) poli, numberOfPoints * sizeof(Point));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, poli);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     }
     else
     {
@@ -321,12 +321,12 @@ void drawSolidPoly( const Point *poli, unsigned int numberOfPoints, Color4F colo
         {
             newPoli[i] = Vertex2F( poli[i].x, poli[i].y );
         }
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         setGLBufferData(newPoli, numberOfPoints * sizeof(Vertex2F));
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
         glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, newPoli);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     }    
 
     glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) numberOfPoints);
@@ -366,12 +366,12 @@ void drawCircle( const Point& center, float radius, float angle, unsigned int se
 
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, sizeof(GLfloat)*2*(segments+2));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments+additionalSegment);
 
     ::free( vertices );
@@ -411,12 +411,12 @@ void drawSolidCircle( const Point& center, float radius, float angle, unsigned i
     
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
     
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, sizeof(GLfloat)*2*(segments+2));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     
     glDrawArrays(GL_TRIANGLE_FAN, 0, (GLsizei) segments+1);
     
@@ -452,12 +452,12 @@ void drawQuadBezier(const Point& origin, const Point& control, const Point& dest
 
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, (segments + 1) * sizeof(Vertex2F));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
     CC_SAFE_DELETE_ARRAY(vertices);
 
@@ -509,12 +509,12 @@ void drawCardinalSpline( PointArray *config, float tension,  unsigned int segmen
 
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, (segments + 1) * sizeof(Vertex2F));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
 
     CC_SAFE_DELETE_ARRAY(vertices);
@@ -543,12 +543,12 @@ void drawCubicBezier(const Point& origin, const Point& control1, const Point& co
 
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, (segments + 1) * sizeof(Vertex2F));
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_LINE_STRIP, 0, (GLsizei) segments + 1);
     CC_SAFE_DELETE_ARRAY(vertices);
 

--- a/cocos2dx/effects/CCGrid.cpp
+++ b/cocos2dx/effects/CCGrid.cpp
@@ -322,7 +322,7 @@ void Grid3D::blit(void)
     //
     // Attributes
     //
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     // Size calculations from calculateVertexPoints().
     unsigned int numOfPoints = (_gridSize.width+1) * (_gridSize.height+1);
 
@@ -344,7 +344,7 @@ void Grid3D::blit(void)
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, 0, _texCoordinates);
 
     glDrawElements(GL_TRIANGLES, (GLsizei) n*6, GL_UNSIGNED_SHORT, _indices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     CC_INCREMENT_GL_DRAWS(1);
 }
 
@@ -538,7 +538,7 @@ void TiledGrid3D::blit(void)
     // Attributes
     //
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POSITION | GL::VERTEX_ATTRIB_FLAG_TEX_COORDS );
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     int numQuads = _gridSize.width * _gridSize.height;
 
     // position
@@ -559,7 +559,7 @@ void TiledGrid3D::blit(void)
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, 0, _texCoordinates);
 
     glDrawElements(GL_TRIANGLES, (GLsizei)n*6, GL_UNSIGNED_SHORT, _indices);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 
     CC_INCREMENT_GL_DRAWS(1);

--- a/cocos2dx/effects/CCGrid.h
+++ b/cocos2dx/effects/CCGrid.h
@@ -32,9 +32,9 @@ THE SOFTWARE.
 #include "textures/CCTexture2D.h"
 #include "CCDirector.h"
 #include "kazmath/mat4.h"
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -106,9 +106,9 @@ protected:
  Grid3D is a 3D grid implementation. Each vertex has 3 dimensions: x,y,z
  */
 class CC_DLL Grid3D : public GridBase
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** create one Grid */
@@ -148,9 +148,9 @@ protected:
  the tiles can be separated from the grid.
 */
 class CC_DLL TiledGrid3D : public GridBase
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** create one Grid */

--- a/cocos2dx/layers_scenes_transitions_nodes/CCLayer.cpp
+++ b/cocos2dx/layers_scenes_transitions_nodes/CCLayer.cpp
@@ -788,7 +788,7 @@ void LayerColor::draw()
     //
     // Attributes
     //
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(_squareVertices, 4 * sizeof(Vertex2F), 0);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
@@ -797,7 +797,7 @@ void LayerColor::draw()
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _squareVertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_FLOAT, GL_FALSE, 0, _squareColors);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     GL::blendFunc( _blendFunc.src, _blendFunc.dst );
 

--- a/cocos2dx/layers_scenes_transitions_nodes/CCLayer.h
+++ b/cocos2dx/layers_scenes_transitions_nodes/CCLayer.h
@@ -33,9 +33,9 @@ THE SOFTWARE.
 #include "platform/CCAccelerometerDelegate.h"
 #include "keypad_dispatcher/CCKeypadDelegate.h"
 #include "cocoa/CCArray.h"
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -211,9 +211,9 @@ All features from Layer are valid, plus the following new features:
 - RGB colors
 */
 class CC_DLL LayerColor : public LayerRGBA, public BlendProtocol
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** creates a fullscreen black layer */

--- a/cocos2dx/misc_nodes/CCMotionStreak.cpp
+++ b/cocos2dx/misc_nodes/CCMotionStreak.cpp
@@ -334,7 +334,7 @@ void MotionStreak::draw()
 
     GL::bindTexture2D( _texture->getName() );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     // Size calculations from ::initWithFade
     setGLBufferData(_vertices, (sizeof(Vertex2F) * _maxPoints * 2), 0);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
@@ -348,7 +348,7 @@ void MotionStreak::draw()
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, _vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, 0, _texCoords);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, 0, _colorPointer);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, (GLsizei)_nuPoints*2);
 

--- a/cocos2dx/misc_nodes/CCMotionStreak.h
+++ b/cocos2dx/misc_nodes/CCMotionStreak.h
@@ -29,9 +29,9 @@ THE SOFTWARE.
 #include "textures/CCTexture2D.h"
 #include "ccTypes.h"
 #include "base_nodes/CCNode.h"
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -44,9 +44,9 @@ NS_CC_BEGIN
  Creates a trailing path.
  */
 class CC_DLL MotionStreak : public NodeRGBA, public TextureProtocol
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** creates and initializes a motion streak with fade in seconds, minimum segments, stroke's width, color, texture filename */

--- a/cocos2dx/misc_nodes/CCProgressTimer.cpp
+++ b/cocos2dx/misc_nodes/CCProgressTimer.cpp
@@ -510,7 +510,7 @@ void ProgressTimer::draw(void)
 
     GL::bindTexture2D( _sprite->getTexture()->getName() );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData((void*) _vertexData, (_vertexDataCount * sizeof(V2F_C4B_T2F)), 0);
 
     int offset = 0;
@@ -525,7 +525,7 @@ void ProgressTimer::draw(void)
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]) , &_vertexData[0].vertices);
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, sizeof(_vertexData[0]), &_vertexData[0].texCoords);
     glVertexAttribPointer( GLProgram::VERTEX_ATTRIB_COLOR, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(_vertexData[0]), &_vertexData[0].colors);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     if(_type == Type::RADIAL)
     {

--- a/cocos2dx/misc_nodes/CCProgressTimer.h
+++ b/cocos2dx/misc_nodes/CCProgressTimer.h
@@ -26,9 +26,9 @@ THE SOFTWARE.
 #define __MISC_NODE_CCPROGRESS_TIMER_H__
 
 #include "sprite_nodes/CCSprite.h"
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -44,9 +44,9 @@ NS_CC_BEGIN
  @since v0.99.1
  */
 class CC_DLL ProgressTimer : public NodeRGBA
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** Types of progress

--- a/cocos2dx/platform/CCImageCommon_cpp.h
+++ b/cocos2dx/platform/CCImageCommon_cpp.h
@@ -29,10 +29,10 @@ THE SOFTWARE.
 #include <ctype.h>
 #include <unistd.h>
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <SDL/SDL.h>
 #include <SDL/SDL_image.h>
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 extern "C"
 {
@@ -323,7 +323,7 @@ bool Image::initWithImageFile(const char * strPath)
     }
 
     CC_SAFE_DELETE_ARRAY(buffer);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     return bRet;
 }

--- a/cocos2dx/sprite_nodes/CCSprite.cpp
+++ b/cocos2dx/sprite_nodes/CCSprite.cpp
@@ -556,12 +556,12 @@ void Sprite::draw(void)
     GL::enableVertexAttribs( GL::VERTEX_ATTRIB_FLAG_POS_COLOR_TEX );
 
 #define kQuadSize sizeof(_quad.bl)
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     long offset = 0;
     setGLBufferData(&_quad, 4 * kQuadSize, 0);
 #else
     long offset = (long)&_quad;
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     // vertex
     int diff = offsetof( V3F_C4B_T2F, vertices);

--- a/cocos2dx/sprite_nodes/CCSprite.h
+++ b/cocos2dx/sprite_nodes/CCSprite.h
@@ -33,9 +33,9 @@ THE SOFTWARE.
 #include "ccTypes.h"
 #include "cocoa/CCDictionary.h"
 #include <string>
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -77,9 +77,9 @@ struct transformValues_;
  * The default anchorPoint in Sprite is (0.5, 0.5).
  */
 class CC_DLL Sprite : public NodeRGBA, public TextureProtocol
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
 

--- a/cocos2dx/support/user_default/CCUserDefaultEmscripten.cpp
+++ b/cocos2dx/support/user_default/CCUserDefaultEmscripten.cpp
@@ -7,7 +7,7 @@
 #include "platform/CCFileUtils.h"
 #include "support/base64.h"
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
 #endif
 
@@ -135,12 +135,12 @@ void UserDefault::setDataForKey(const char* pKey, const Data& value) {
     }
 }
 
-#ifndef EMSCRIPTEN
+#ifndef __EMSCRIPTEN__
 std::map<std::string, std::string> localStorage;
 #endif
 
 string UserDefault::getStringForKey(const char* pKey, const std::string & defaultValue) {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     static char* cbuffer = new char[16 * 1024]; // 16kb
     bool isSet = EM_ASM_DOUBLE({
                                    var key = Pointer_stringify($0);
@@ -172,7 +172,7 @@ void UserDefault::setStringForKey(const char* pKey, const std::string & value) {
         return;
     }
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     EM_ASM_ARGS({
                     var key = Pointer_stringify($0);
                     var value = Pointer_stringify($1);

--- a/cocos2dx/textures/CCTexture2D.cpp
+++ b/cocos2dx/textures/CCTexture2D.cpp
@@ -1150,7 +1150,7 @@ void Texture2D::drawAtPoint(const Point& point)
     GL::bindTexture2D( _name );
 
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, 8 * sizeof(GLfloat), 0);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
@@ -1159,7 +1159,7 @@ void Texture2D::drawAtPoint(const Point& point)
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, 0, coordinates);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
@@ -1183,7 +1183,7 @@ void Texture2D::drawInRect(const Rect& rect)
 
     GL::bindTexture2D( _name );
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     setGLBufferData(vertices, 8 * sizeof(GLfloat), 0);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
@@ -1192,7 +1192,7 @@ void Texture2D::drawInRect(const Rect& rect)
 #else
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_POSITION, 2, GL_FLOAT, GL_FALSE, 0, vertices);
     glVertexAttribPointer(GLProgram::VERTEX_ATTRIB_TEX_COORDS, 2, GL_FLOAT, GL_FALSE, 0, coordinates);
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
 }
 

--- a/cocos2dx/textures/CCTexture2D.h
+++ b/cocos2dx/textures/CCTexture2D.h
@@ -32,9 +32,9 @@ THE SOFTWARE.
 #include "cocoa/CCObject.h"
 #include "cocoa/CCGeometry.h"
 #include "ccTypes.h"
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include "base_nodes/CCGLBufferedNode.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 NS_CC_BEGIN
 
@@ -59,9 +59,9 @@ class GLProgram;
 * Be aware that the content of the generated textures will be upside-down!
 */
 class CC_DLL Texture2D : public Object
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 , public GLBufferedNode
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 {
 public:
     /** @typedef Texture2D::PixelFormat

--- a/cocos2dx/textures/CCTextureCache.cpp
+++ b/cocos2dx/textures/CCTextureCache.cpp
@@ -40,10 +40,10 @@ THE SOFTWARE.
 #include "cocoa/CCString.h"
 
 
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
 #include <emscripten/emscripten.h>
 #include "platform/emscripten/CCTextureCacheEmscripten.h"
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
 using namespace std;
 
@@ -57,11 +57,11 @@ TextureCache * TextureCache::getInstance()
 {
     if (!_sharedTextureCache)
     {
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
         _sharedTextureCache = new TextureCacheEmscripten();
 #else
         _sharedTextureCache = new TextureCache();
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
     }
     return _sharedTextureCache;
 }

--- a/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
+++ b/extensions/GUI/CCControlExtension/CCControlSwitch.cpp
@@ -168,12 +168,12 @@ void ControlSwitchSprite::draw()
     glUniform1i(_maskLocation, 1);
 
 #define kQuadSize sizeof(_quad.bl)
-#ifdef EMSCRIPTEN
+#ifdef __EMSCRIPTEN__
     long offset = 0;
     setGLBufferData(&_quad, 4 * kQuadSize, 0);
 #else
     long offset = (long)&_quad;
-#endif // EMSCRIPTEN
+#endif // __EMSCRIPTEN__
 
     // vertex
     int diff = offsetof( V3F_C4B_T2F, vertices);


### PR DESCRIPTION
The later is always defined by clang, the former is legacy and defined
by emcc when in non-STRICT mode.